### PR TITLE
Add LDAP container scripts

### DIFF
--- a/ldap/docker/Dockerfile
+++ b/ldap/docker/Dockerfile
@@ -1,0 +1,6 @@
+# Simple Dockerfile for OpenLDAP with TLS support
+# Uses the osixia/openldap base image which already contains OpenLDAP and utilities.
+FROM osixia/openldap:1.5.0
+
+# No additional packages are required for a basic setup, but this file exists
+# so the image can be rebuilt and extended if desired.

--- a/ldap/scripts/create-user.sh
+++ b/ldap/scripts/create-user.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Create a user entry in the running LDAP server.
+# Usage: create-user.sh <uid> <first-name> <last-name> <password>
+# Example: ./create-user.sh jdoe John Doe s3cr3t
+
+set -e
+
+if [ $# -ne 4 ]; then
+  echo "Usage: $0 <uid> <first-name> <last-name> <password>"
+  exit 1
+fi
+
+UID="$1"
+GIVEN_NAME="$2"
+LAST_NAME="$3"
+PASSWORD="$4"
+
+# Generate LDIF content for the new user.
+# inetOrgPerson is a common object class for user accounts.
+LDIF="dn: uid=${UID},ou=people,dc=example,dc=org
+objectClass: inetOrgPerson
+uid: ${UID}
+cn: ${GIVEN_NAME} ${LAST_NAME}
+givenName: ${GIVEN_NAME}
+sn: ${LAST_NAME}
+userPassword: ${PASSWORD}
+"
+
+# Pass the LDIF to ldapadd running inside the container.
+echo "$LDIF" | docker exec -i ldap-server ldapadd -x -D "cn=admin,dc=example,dc=org" -w admin -H ldaps://localhost
+
+echo "User '${UID}' added."
+

--- a/ldap/scripts/get-user.sh
+++ b/ldap/scripts/get-user.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Retrieve a user entry from the running LDAP server.
+# Usage: get-user.sh <uid>
+
+set -e
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <uid>"
+  exit 1
+fi
+
+UID="$1"
+
+docker exec ldap-server ldapsearch -x -LLL -b "dc=example,dc=org" "uid=${UID}"
+
+

--- a/ldap/scripts/start.sh
+++ b/ldap/scripts/start.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Start an OpenLDAP container with persistent storage and TLS using an internal CA.
+# This script works on macOS and Linux as long as Docker is installed.
+
+set -e
+
+# Location of this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Directories for persistent data and configuration
+DATA_DIR="$ROOT_DIR/data"
+CONFIG_DIR="$ROOT_DIR/config"
+CERT_DIR="$ROOT_DIR/certs"
+
+mkdir -p "$DATA_DIR" "$CONFIG_DIR" "$CERT_DIR"
+
+# These files should be provided by your internal CA
+CA_CRT="$CERT_DIR/ca.crt"
+SERVER_CRT="$CERT_DIR/server.crt"
+SERVER_KEY="$CERT_DIR/server.key"
+
+# Build the Docker image (located in ldap/docker)
+docker build -t ldap-example "$ROOT_DIR/docker"
+
+# Run the container
+# 389: LDAP without TLS
+# 636: LDAP over TLS (LDAPS)
+docker run -d --name ldap-server \
+  -p 389:389 -p 636:636 \
+  -v "$DATA_DIR:/var/lib/ldap" \
+  -v "$CONFIG_DIR:/etc/ldap/slapd.d" \
+  -v "$CERT_DIR:/container/service/slapd/assets/certs" \
+  -e LDAP_ORGANISATION="Example Org" \
+  -e LDAP_DOMAIN="example.org" \
+  -e LDAP_ADMIN_PASSWORD="admin" \
+  -e LDAP_TLS=true \
+  -e LDAP_TLS_CRT_FILENAME="$(basename "$SERVER_CRT")" \
+  -e LDAP_TLS_KEY_FILENAME="$(basename "$SERVER_KEY")" \
+  -e LDAP_TLS_CA_CRT_FILENAME="$(basename "$CA_CRT")" \
+  ldap-example
+
+echo "OpenLDAP container 'ldap-server' started." 


### PR DESCRIPTION
## Summary
- add an OpenLDAP Dockerfile
- add helper scripts to start the container, create and get users

## Testing
- `bash -n ldap/scripts/start.sh && bash -n ldap/scripts/create-user.sh && bash -n ldap/scripts/get-user.sh`


------
https://chatgpt.com/codex/tasks/task_e_68613920c31c832b8e0013b892ffdae7