### PR TITLE
Add TLS utilities for internal CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ keytool -genkeypair -alias keycloak -keyalg RSA -keystore keycloak.jks -storepas
 ```
 
 Applications then need to present their client certificate when talking to Keycloak over HTTPS.
+You can also use the helper scripts under `tls/` to create a local CA and issue certificates:
+```bash
+./tls/ca/create-ca.sh
+./tls/client-certs/generate-client-cert.sh alice
+./tls/server-certs/generate-server-cert.sh myservice
+```
+
 
 ### 3. Use OAuth 2.0 / OIDC from an Application
 

--- a/tls/README.md
+++ b/tls/README.md
@@ -1,0 +1,24 @@
+# TLS Utilities
+
+This directory provides simple scripts to create a local certificate authority (CA) and to issue client and server certificates signed by that CA.
+
+## Structure
+- `ca/create-ca.sh` – generates a root CA key and self‑signed certificate. All CA artifacts remain inside the `ca` directory.
+- `client-certs/generate-client-cert.sh` – generates a client key and certificate signed by the CA.
+- `server-certs/generate-server-cert.sh` – generates a server key and certificate signed by the CA.
+
+## Usage
+1. **Create the CA**
+   ```bash
+   ./ca/create-ca.sh
+   ```
+2. **Generate a client certificate**
+   ```bash
+   ./client-certs/generate-client-cert.sh alice
+   ```
+3. **Generate a server certificate**
+   ```bash
+   ./server-certs/generate-server-cert.sh myserver
+   ```
+Each certificate is placed in a subdirectory named after the entity (e.g. `alice/` or `myserver/`).
+

--- a/tls/ca/create-ca.sh
+++ b/tls/ca/create-ca.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Simple script to create a local root certificate authority.
+# All artifacts are stored in the same directory as this script.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CA_DIR="$SCRIPT_DIR"
+
+mkdir -p "$CA_DIR/certs" "$CA_DIR/private" "$CA_DIR/newcerts"
+chmod 700 "$CA_DIR/private"
+
+# Initialize files used by OpenSSL
+[ -f "$CA_DIR/index.txt" ] || touch "$CA_DIR/index.txt"
+[ -f "$CA_DIR/serial" ] || echo 1000 > "$CA_DIR/serial"
+
+CA_KEY="$CA_DIR/private/ca.key.pem"
+CA_CERT="$CA_DIR/certs/ca.cert.pem"
+
+if [ -f "$CA_CERT" ]; then
+  echo "CA certificate already exists at $CA_CERT"
+  exit 0
+fi
+
+# Generate private key
+openssl genrsa -out "$CA_KEY" 4096
+
+# Self-sign the root certificate
+openssl req -x509 -new -nodes -key "$CA_KEY" \
+  -sha256 -days 3650 \
+  -subj "/CN=Example Internal Root CA" \
+  -out "$CA_CERT"
+
+echo "Root CA created at $CA_CERT"

--- a/tls/client-certs/generate-client-cert.sh
+++ b/tls/client-certs/generate-client-cert.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Generate a client key and certificate signed by the internal CA.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+CA_DIR="$ROOT_DIR/ca"
+
+if [ ! -f "$CA_DIR/certs/ca.cert.pem" ] || [ ! -f "$CA_DIR/private/ca.key.pem" ]; then
+  echo "CA not found. Run $CA_DIR/create-ca.sh first." >&2
+  exit 1
+fi
+
+NAME="${1:-client}"
+OUT_DIR="$SCRIPT_DIR/$NAME"
+mkdir -p "$OUT_DIR"
+
+CLIENT_KEY="$OUT_DIR/$NAME.key.pem"
+CLIENT_CSR="$OUT_DIR/$NAME.csr.pem"
+CLIENT_CERT="$OUT_DIR/$NAME.cert.pem"
+
+openssl genrsa -out "$CLIENT_KEY" 2048
+
+openssl req -new -key "$CLIENT_KEY" -subj "/CN=$NAME" -out "$CLIENT_CSR"
+
+openssl x509 -req -in "$CLIENT_CSR" \
+  -CA "$CA_DIR/certs/ca.cert.pem" -CAkey "$CA_DIR/private/ca.key.pem" \
+  -CAcreateserial -out "$CLIENT_CERT" -days 365 -sha256
+
+echo "Client certificate created at $CLIENT_CERT"

--- a/tls/server-certs/generate-server-cert.sh
+++ b/tls/server-certs/generate-server-cert.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Generate a server key and certificate signed by the internal CA.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+CA_DIR="$ROOT_DIR/ca"
+
+if [ ! -f "$CA_DIR/certs/ca.cert.pem" ] || [ ! -f "$CA_DIR/private/ca.key.pem" ]; then
+  echo "CA not found. Run $CA_DIR/create-ca.sh first." >&2
+  exit 1
+fi
+
+NAME="${1:-server}"
+OUT_DIR="$SCRIPT_DIR/$NAME"
+mkdir -p "$OUT_DIR"
+
+SERVER_KEY="$OUT_DIR/$NAME.key.pem"
+SERVER_CSR="$OUT_DIR/$NAME.csr.pem"
+SERVER_CERT="$OUT_DIR/$NAME.cert.pem"
+
+openssl genrsa -out "$SERVER_KEY" 2048
+
+openssl req -new -key "$SERVER_KEY" -subj "/CN=$NAME" -out "$SERVER_CSR"
+
+openssl x509 -req -in "$SERVER_CSR" \
+  -CA "$CA_DIR/certs/ca.cert.pem" -CAkey "$CA_DIR/private/ca.key.pem" \
+  -CAcreateserial -out "$SERVER_CERT" -days 365 -sha256
+
+echo "Server certificate created at $SERVER_CERT"


### PR DESCRIPTION
## Summary
- add `tls` directory with CA, client, and server certificate scripts
- document usage of TLS helper scripts
- mention TLS scripts in the project README

## Testing
- `bash -n tls/ca/create-ca.sh`
- `bash -n tls/client-certs/generate-client-cert.sh`
- `bash -n tls/server-certs/generate-server-cert.sh`


------
https://chatgpt.com/codex/tasks/task_e_68613d18f218832b9af298b2f7d3d245