### PR TITLE
Add local LDAP server setup

### DIFF
--- a/ldap/.env.example
+++ b/ldap/.env.example
@@ -1,0 +1,8 @@
+# Example environment overrides for docker-compose
+# UID and GID control the user inside the container
+UID=1000
+GID=1000
+# Time zone
+TZ=UTC
+# Base DN for LDAP
+LLDAP_LDAP_BASE_DN=dc=example,dc=com

--- a/ldap/.gitignore
+++ b/ldap/.gitignore
@@ -1,0 +1,4 @@
+# Local runtime data for lldap
+secrets/
+data/
+certs/

--- a/ldap/README.md
+++ b/ldap/README.md
@@ -1,0 +1,53 @@
+# Local LLDAP Server
+
+This directory contains a minimal setup for running [lldap](https://github.com/lldap/lldap)
+on your local machine using Docker Compose. It relies on the TLS utilities in
+`../tls` to generate an internal certificate authority (CA) and a server
+certificate for lldap.
+
+## Prerequisites
+- [Docker](https://docs.docker.com/get-docker/) and `docker compose` installed.
+- Bash shell utilities available.
+
+## Setup
+1. **Create the internal CA and server certificate**
+   ```bash
+   # from the repository root
+   ./tls/ca/create-ca.sh
+   ./tls/server-certs/generate-server-cert.sh lldap
+   # copy or link the generated certificate
+   mkdir -p ldap/certs
+   cp tls/server-certs/lldap/lldap.cert.pem ldap/certs/
+   cp tls/server-certs/lldap/lldap.key.pem ldap/certs/
+   ```
+
+2. **Generate application secrets**
+   ```bash
+   cd ldap
+   ./generate_secrets.sh
+   ```
+   This creates the files under `ldap/secrets/` used by the container.
+
+3. **Start the server**
+   ```bash
+   docker compose up -d
+   ```
+   The web UI will be available on [https://localhost:17170](https://localhost:17170)
+   and LDAPS on port `6360`.
+
+The default admin password is written to `secrets/admin_pass` by the
+`generate_secrets.sh` script. Edit that file to change it before starting the
+service.
+
+## Trusting the Internal CA
+To trust the server certificate, import `tls/ca/certs/ca.cert.pem` into your
+system or application's trusted certificate store. The lldap container uses the
+certificate generated in step 1, which is signed by this CA.
+
+## Cleaning Up
+To stop and remove the container:
+```bash
+docker compose down
+```
+Remove the `data`, `secrets`, and `certs` directories if you want to start from
+scratch.

--- a/ldap/docker-compose.yml
+++ b/ldap/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+services:
+  lldap:
+    image: lldap/lldap:stable
+    ports:
+      - "17170:17170"  # web interface
+      - "3890:3890"    # LDAP
+      - "6360:6360"    # LDAPS
+    environment:
+      UID: ${UID:-1000}
+      GID: ${GID:-1000}
+      TZ: ${TZ:-UTC}
+      LLDAP_JWT_SECRET_FILE: /secrets/jwt_secret
+      LLDAP_KEY_SEED_FILE: /secrets/key_seed
+      LLDAP_LDAP_BASE_DN: ${LLDAP_LDAP_BASE_DN:-dc=example,dc=com}
+      LLDAP_LDAP_USER_PASS_FILE: /secrets/admin_pass
+      LLDAP_LDAPS_OPTIONS__ENABLED: "true"
+      LLDAP_LDAPS_OPTIONS__CERT_FILE: /certs/lldap.cert.pem
+      LLDAP_LDAPS_OPTIONS__KEY_FILE: /certs/lldap.key.pem
+    volumes:
+      - ./data:/data
+      - ./secrets:/secrets:ro
+      - ./certs:/certs:ro

--- a/ldap/generate_secrets.sh
+++ b/ldap/generate_secrets.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Generate random secrets used by lldap
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SECRETS_DIR="$SCRIPT_DIR/secrets"
+mkdir -p "$SECRETS_DIR"
+
+random() {
+  tr -dc 'A-Za-z0-9!#%&()*+,-./:;<=>?@[\\]^_{|}~' </dev/urandom | head -c 32
+}
+
+[ -f "$SECRETS_DIR/jwt_secret" ] || random > "$SECRETS_DIR/jwt_secret"
+[ -f "$SECRETS_DIR/key_seed" ] || random > "$SECRETS_DIR/key_seed"
+
+if [ ! -f "$SECRETS_DIR/admin_pass" ]; then
+  echo "admin" > "$SECRETS_DIR/admin_pass"
+  echo "Default admin password written to $SECRETS_DIR/admin_pass. Change it." >&2
+fi


### PR DESCRIPTION
## Summary
- add `ldap/` directory with docker-compose configuration for running lldap locally
- provide script to generate secrets
- document TLS setup using the existing CA utilities

## Testing
- `bash -n ldap/generate_secrets.sh`
- `docker compose config`

------
https://chatgpt.com/codex/tasks/task_e_686140457ad4832bafd6f517544e6e43