### PR TITLE
Add docker build check for AWS CLI

### DIFF
--- a/tenant-backup/Dockerfile
+++ b/tenant-backup/Dockerfile
@@ -1,0 +1,15 @@
+FROM amazon/aws-cli:latest AS awscli
+
+FROM alpine:3.20.2
+RUN apk add --no-cache gcompat git curl
+
+# Copy AWS CLI and all dependencies from the awscli stage
+COPY --from=awscli /usr/local/aws-cli/ /usr/local/aws-cli/
+COPY --from=awscli /usr/local/bin/aws /usr/local/bin/aws
+
+# Verify that the AWS CLI can run in the Alpine environment
+RUN aws --version
+
+ENV PATH="/usr/local/bin:${PATH}"
+
+CMD ["sh"]


### PR DESCRIPTION
## Summary
- update `tenant-backup/Dockerfile`
- run `aws --version` during build to verify CLI works

## Testing
- `docker build tenant-backup -t tenant-backup:latest` *(fails: Cannot connect to Docker daemon)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6865aa896450832bb3433baf1b34b674